### PR TITLE
[TASK] Fix issues with TYPO3 10 LTS

### DIFF
--- a/Classes/Controller/MoreLikeThisController.php
+++ b/Classes/Controller/MoreLikeThisController.php
@@ -19,10 +19,11 @@ use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Solr\Document\Document;
 use ApacheSolrForTypo3\Solrmlt\Configuration\PluginConfiguration;
 use ApacheSolrForTypo3\Solrmlt\Query\Builder;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
-use TYPO3\CMS\Extbase\Service\FlexFormService;
+use TYPO3\CMS\Core\Service\FlexFormService;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -113,7 +114,9 @@ class MoreLikeThisController extends ActionController
         if ($this->search === null) {
             /** @var \ApacheSolrForTypo3\Solr\ConnectionManager $solrConnection */
             $typoScriptFrontendController = $GLOBALS['TSFE'];
-            $solrConnection = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionByPageId($typoScriptFrontendController->id, $typoScriptFrontendController->sys_language_uid, $typoScriptFrontendController->MP);
+            $context = GeneralUtility::makeInstance(Context::class);
+            $languageUid = (int)$context->getPropertyFromAspect('language', 'id');
+            $solrConnection = GeneralUtility::makeInstance(ConnectionManager::class)->getConnectionByPageId($typoScriptFrontendController->id, $languageUid, $typoScriptFrontendController->MP);
             $this->search = GeneralUtility::makeInstance(Search::class, $solrConnection);
         }
 

--- a/Configuration/FlexForms/MoreLikeThis.xml
+++ b/Configuration/FlexForms/MoreLikeThis.xml
@@ -35,7 +35,7 @@
 						<TCEforms>
 							<label>Create the query string from</label>
 							<config>
-								<type>select</type>
+								<type>selectSingle</type>
 								<items type="array">
 									<numIndex index="0" type="array">
 										<numIndex index="0">Title of the current page</numIndex>

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,17 @@
 		"source": "https://github.com/TYPO3-Solr/ext-solrmlt"
 	},
 	"require": {
-		"php": ">=7.0 <7.5",
-		"typo3/cms-core": "^8.7.0 || ^9.5 || ^10.4",
-		"typo3/cms-extbase": "^8.7.0 || ^9.5 || ^10.4",
-		"typo3/cms-frontend": "^8.7.0 || ^9.5 || ^10.4",
-		"typo3/cms-fluid": "^8.7.0 || ^9.5 || ^10.4",
-		"typo3/cms-tstemplate": "^8.7.0 || ^9.5 || ^10.4"
+		"php": ">=7.2 <7.5",
+		"typo3/cms-core": "^9.5 || ^10.4",
+		"typo3/cms-extbase": "^9.5 || ^10.4",
+		"typo3/cms-frontend": "^9.5 || ^10.4",
+		"typo3/cms-fluid": "^9.5 || ^10.4",
+		"typo3/cms-tstemplate": "^9.5 || ^10.4",
+		"apache-solr-for-typo3/solr": "^11.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^6.0 || ^7.5.6 || ^8",
-		"nimut/testing-framework": "^4.0.0 || ^5.0.0"
+		"nimut/testing-framework": "^5.0.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,8 +15,8 @@ $EM_CONF[$_EXTKEY] = [
     'clearCacheOnLoad' => 0,
     'constraints' => [
         'depends' => [
-            'solr' => '9.0.0-',
-            'typo3' => '8.7.0-10.4.99',
+            'solr' => '11.0.0-',
+            'typo3' => '9.5.0-10.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
This pull request:

* Uses the FlexformService from the core instead of extbase
* Uses the renderType selectSingle in the flexform
* Updates the dependencies

Fixes: #20 