### PR TITLE
[TASK] Change configuration files to TYPO3 file extensions

### DIFF
--- a/Configuration/TypoScript/MoreLikeThis/setup.txt
+++ b/Configuration/TypoScript/MoreLikeThis/setup.txt
@@ -1,4 +1,1 @@
-plugin.tx_solr {
-	moreLikeThis {
-	}
-}
+@import 'EXT:solrmlt/Configuration/TypoScript/MoreLikeThis/setup.typoscript'

--- a/Configuration/TypoScript/MoreLikeThis/setup.typoscript
+++ b/Configuration/TypoScript/MoreLikeThis/setup.typoscript
@@ -1,0 +1,4 @@
+plugin.tx_solr {
+	moreLikeThis {
+	}
+}


### PR DESCRIPTION
# What this pr does

This Pull-Request change the file extensions from TypoScript files.
Previously TypoScript files use the file extension `txt` which is replaced with `typoscript`.

Hints within code and documentations are updated according to these changes.

All changes them self should no effect current installations, since the old files are still in place and include the new ones. 

*Note:* There are no changes to the TypoScript itself.

# How to test

1. Open the TypoScript object browser inside of the backend
2. You should see the setup, even if you include the old files.

Since there are not Changes to the TypoScript itself only the includes needs to be testet.

Fixes: #23  
