### PR TITLE
Release 10.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, release-10.0.x ]
     tags:
       - "**"
   pull_request:
-    branches: [ master ]
+    branches: [ master, release-10.0.x ]
 
 env:
   EXT_SOLR_VERSION: 'dev-release-11.1.x'
@@ -28,10 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-#        PHP: [ '7.2', '7.3', '7.4' ]
-#        TYPO3: [ '^10.4', '10.4.x-dev' ]
-        PHP: [ '7.4' ]
-        TYPO3: [ '10.4.x-dev' ]
+        PHP: [ '7.2', '7.3', '7.4' ]
+        TYPO3: [ '^10.4', '10.4.x-dev' ]
     env:
       TYPO3_VERSION: ${{ matrix.TYPO3 }}
 

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,63 @@
+filter:
+  excluded_paths:
+    - 'Documentation/*'
+    - 'Tests/*'
+    - 'Resources/Public/JavaScript/*'
+  paths:
+    - 'Classes/*'
+    - 'Configuration/*'
+  dependency_paths:
+    - ".Build/vendor"
+
+tools:
+  php_cpd:
+    enabled: true
+
+  php_code_sniffer:
+    enabled: true
+    config:
+      standard: TYPO3CMS
+
+  # we do this on GitHub actions
+  php_cs_fixer:
+    enabled: false
+
+  php_mess_detector:
+    enabled: true
+    config:
+      controversial_rules:
+        superglobals: false
+
+  php_pdepend:
+    enabled: true
+
+  php_analyzer:
+    enabled: true
+
+  external_code_coverage:
+    runs: 2
+    timeout: 2400
+
+checks:
+    php:
+        excluded_dependencies:
+            - typo3/cms-install
+        avoid_superglobals: false
+
+build:
+  environment:
+    # We want to test with the smallest supported by TYPO3 PHP version
+    php: 7.2
+  dependencies:
+    override:
+      - composer install --dev --no-interaction --no-scripts
+  nodes:
+    analysis:
+      dependencies:
+        after:
+          - composer require --dev squizlabs/php_codesniffer:^3.6
+#      tests:
+#        override:
+#          - php-scrutinizer-run
+#          - command: phpcs-run
+#            use_website_config: false

--- a/Classes/Query/Builder.php
+++ b/Classes/Query/Builder.php
@@ -119,9 +119,9 @@ class Builder
      * @param TypoScriptFrontendController $TSFE
      * @return string
      */
-    protected function getSiteHashFilterForTSFE(TypoScriptFrontendController $TSFE)
+    protected function getSiteHashFilterForTSFE(TypoScriptFrontendController $TSFE): string
     {
-            /** @var $siteRepository SiteRepository */
+        /* @var SiteRepository $siteRepository */
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         return "siteHash:".$siteRepository->getSiteByPageId($TSFE->id)->getSiteHash();
     }


### PR DESCRIPTION
This is the maintenance release only.

As we're planning to simplify the extension and dependency
handling we're harmonize the extension version with TYPO3.
So the next version of solrmlt is 10.0.0 and compatible
with TYPO3 10 LTS and EXT:solr 11.1.0.

Please read the release notes:
https://github.com/TYPO3-Solr/ext-solrfluidgrouping/releases/tag/10.0.0